### PR TITLE
Getter rewrite

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,26 +1,61 @@
 import Colors from "./src/colors.js"
-const colors = new Colors()
 
-colors.bold().red().and('Hello ').blue().log('World!')
+const colors = Colors()
 
+colors.bold.red.and('Hello ').blue.log('World!')
+
+colors.log('Colors displayed as:')
+colors.italic.log('Standard')
+colors.italic.log('Bold')
 //Colors
+colors.bold.log('Colors')
 colors
-  .bold()
-  .black().and('black ')
-  .red().and('red ')
-  .green().and('green ')
-  .yellow().and('yellow ')
-  .blue().and('blue ')
-  .magenta().and('magenta ')
-  .cyan().and('cyan ')
-  .white().log('white')
+  .black.and('black ')
+  .red.and('red ')
+  .green.and('green ')
+  .yellow.and('yellow ')
+  .blue.and('blue ')
+  .magenta.and('magenta ')
+  .cyan.and('cyan ')
+  .white.log('white')
+colors
+  .bblack.and('black ')
+  .bred.and('red ')
+  .bgreen.and('green ')
+  .byellow.and('yellow ')
+  .bblue.and('blue ')
+  .bmagenta.and('magenta ')
+  .bcyan.and('cyan ')
+  .bwhite.log('white')
 
-//Styles
+//Backgrounds
+colors.bold.log("Backgrounds")
 colors
-  .yellow().bold().then('bold ')
-  .yellow().dim().then('dim ')
-  .yellow().italic().then('italic ')
-  .yellow().underline().then('underline').then(' ')
-  .yellow().inverse().then('inverse').then(' ')
-  .yellow().hidden().then('hidden ').then(' ')
-  .yellow().strikethrough().log('strikethrough')
+  .bgblack.and('black ')
+  .bgred.and('red ')
+  .bggreen.and('green ')
+  .bgyellow.and('yellow ')
+  .bgblue.and('blue ')
+  .bgmagenta.and('magenta ')
+  .bgcyan.and('cyan ')
+  .bgwhite.log('white')
+colors
+  .bbgblack.and('black ')
+  .bbgred.and('red ')
+  .bbggreen.and('green ')
+  .bbgyellow.and('yellow ')
+  .bbgblue.and('blue ')
+  .bbgmagenta.and('magenta ')
+  .bbgcyan.and('cyan ')
+  .bbgwhite.log('white').then('')
+//Styles
+colors.bold.log("Styles")
+
+colors
+  .yellow.bold.then('bold ')
+  .yellow.dim.then('dim ')
+  .yellow.italic.then('italic ')
+  .yellow.underline.then('underline').then(' ')
+  .yellow.inverse.then('inverse').then(' ')
+  .yellow.hidden.then('hidden ').then(' ')
+  .yellow.strikethrough.log('strikethrough')

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fluent-interface-colors",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fluent-interface-colors",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "license": "ISC",
       "devDependencies": {
         "nodemon": "^3.1.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fluent-interface-colors",
   "type": "module",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "JavaScript fluent interface pattern implementation done with coloring for console messages",
   "main": "index.js",
   "scripts": {

--- a/src/ansiCodes.js
+++ b/src/ansiCodes.js
@@ -1,0 +1,48 @@
+const ansi = {
+  //Colors
+  'black': '\x1b[30m',
+  'red': '\x1b[31m',
+  'green': '\x1b[32m',
+  'yellow': '\x1b[33m',
+  'blue': '\x1b[34m',
+  'magenta': '\x1b[35m',
+  'cyan': '\x1b[36m',
+  'white': '\x1b[37m',
+  //Bold (bright) colors
+  'bblack': '\x1b[90m',
+  'bred': '\x1b[91m',
+  'bgreen': '\x1b[92m',
+  'byellow': '\x1b[93m',
+  'bblue': '\x1b[94m',
+  'bmagenta': '\x1b[95m',
+  'bcyan': '\x1b[96m',
+  'bwhite': '\x1b[97m',
+  //Styles
+  'bold': '\x1b[1m',
+  'dim': '\x1b[2m',
+  'italic': '\x1b[3m',
+  'underline': '\x1b[4m',
+  'inverse': '\x1b[7m',
+  'hidden': '\x1b[8m',
+  'strikethrough': '\x1b[9m',
+  //Backgrounds
+  'bgblack': '\x1b[40m',
+  'bgred': '\x1b[41m',
+  'bggreen': '\x1b[42m',
+  'bgyellow': '\x1b[43m',
+  'bgblue': '\x1b[44m',
+  'bgmagenta': '\x1b[45m',
+  'bgcyan': '\x1b[46m',
+  'bgwhite': '\x1b[47m',
+  //Bold (bright) backgroudns
+  'bbgblack': '\x1b[100m',
+  'bbgred': '\x1b[101m',
+  'bbggreen': '\x1b[102m',
+  'bbgyellow': '\x1b[103m',
+  'bbgblue': '\x1b[104m',
+  'bbgmagenta': '\x1b[105m',
+  'bbgcyan': '\x1b[106m',
+  'bbgwhite': '\x1b[107m'
+}
+
+export default ansi

--- a/src/colors.js
+++ b/src/colors.js
@@ -1,22 +1,4 @@
-const colors = {
-  //Colors
-  'black': '\x1b[30m',
-  'red': '\x1b[31m',
-  'green': '\x1b[32m',
-  'yellow': '\x1b[33m',
-  'blue': '\x1b[34m',
-  'magenta': '\x1b[35m',
-  'cyan': '\x1b[36m',
-  'white': '\x1b[37m',
-  //Styles
-  'bold': '\x1b[1m',
-  'dim': '\x1b[2m',
-  'italic': '\x1b[3m',
-  'underline': '\x1b[4m',
-  'inverse': '\x1b[7m',
-  'hidden': '\x1b[8m',
-  'strikethrough': '\x1b[9m'
-}
+import ansi from "./ansiCodes.js"
 
 export default function() {
   //Message history stack
@@ -24,31 +6,36 @@ export default function() {
   //Message currently styled
   let stylePrefix = ''
 
-  //Define color functions dynamically, based on array elements
-  Object.keys(colors).forEach((key) => {
-    this[key] = () => {
-      stylePrefix += colors[key]
-      return this
+  const colors = {
+    //Finalize all messages and render to console
+    log: (newMessage) => {
+      console.log(`${message}${stylePrefix}${newMessage}\x1b[0m`)
+      stylePrefix = ''
+      message = ''
+      return colors
+    },
+    //Lock in current message and styling, and reset styles for the next message.
+    then: (newMessage) => {
+      message += `${stylePrefix}${newMessage}\x1b[0m`
+      stylePrefix = ''
+      return colors
+    },
+    //Lock in current message and styling without resetting styles
+    and: (newMessage) => {
+      message += `${stylePrefix}${newMessage}`
+      return colors
     }
+  }
+
+  //Define color functions dynamically, based on array elements
+  Object.keys(ansi).forEach((key) => {
+    Object.defineProperty(colors, key, {
+      get: () => { 
+        stylePrefix += ansi[key]
+        return colors
+      }
+    })
   })
 
-  //Lock in current message and styling, and reset styles for the next message.
-  this.then = (newMessage) => {
-    message += `${stylePrefix}${newMessage}\x1b[0m`
-    stylePrefix = ''
-    return this
-  }
-  //Lock in current message and styling without resetting styles
-  this.and = (newMessage) => {
-    message += `${stylePrefix}${newMessage}`
-    return this
-  }
-  
-  //Finalize all messages and render to console
-  this.log = (newMessage) => {
-    console.log(`${message}${stylePrefix}${newMessage}\x1b[0m`)
-    stylePrefix = ''
-    message = ''
-    return this
-  }
+  return colors
 }


### PR DESCRIPTION
Rewrites the project to use object getters and therefore eliminate the need to include parentheses after every style.
Also adds missing ANSI codes.